### PR TITLE
Fix Docker build error for pantry-api

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:22-alpine
 
+RUN apk add --no-cache python3 py3-setuptools make g++
+
 RUN mkdir /app
 RUN mkdir /app/data
 RUN mkdir /app/data/upload

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,8 @@ version: '2'
 services:
   pantry-api:
     build:
-      context: https://github.com/kevdog114/pantry.git
+      context: .
       dockerfile: api/Dockerfile
-    pull_policy: build
     ports:
       - 4300:4300
     env_file:
@@ -14,12 +13,11 @@ services:
       - pantry_data:/app/data
   pantry-ui:
     build:
-      context: https://github.com/kevdog114/pantry.git
+      context: .
       dockerfile: ui/pantry-ui/Dockerfile
       args:
         - api_baseurl=${api_baseurl}
         - site_title=${site_title}
-    pull_policy: build
     ports:
       - 4200:4200
 


### PR DESCRIPTION
- Modified docker-compose.yml to use local build context instead of remote git repository.
- Removed invalid pull_policy from docker-compose.yml.
- Added python3, py3-setuptools, make, and g++ to api/Dockerfile to fix node-gyp build error for sqlite3.