### PR TITLE
feat: Make Gemini models configurable via environment variables

### DIFF
--- a/api/src/controllers/GeminiController.ts
+++ b/api/src/controllers/GeminiController.ts
@@ -20,12 +20,12 @@ const geminiConfig = {
 };
 
 const geminiModel = googleAI.getGenerativeModel({
-  model: "gemini-1.5-flash",
+  model: process.env.GEMINI_TEXT_MODEL || "gemini-1.5-flash",
   ...geminiConfig,
 });
 
 const geminiVisionModel = googleAI.getGenerativeModel({
-    model: "gemini-pro-vision",
+    model: process.env.GEMINI_VISION_MODEL || "gemini-pro-vision",
     ...geminiConfig,
 })
 


### PR DESCRIPTION
This commit updates the `GeminiController` to allow the Gemini text and vision models to be configured using environment variables.

- `GEMINI_TEXT_MODEL` is used for the text model, defaulting to "gemini-1.5-flash".
- `GEMINI_VISION_MODEL` is used for the vision model, defaulting to "gemini-pro-vision".

This change provides greater flexibility for deploying the application in different environments.