### PR TITLE
Fix: Navigate to view page after saving product or recipe

### DIFF
--- a/ui/pantry-ui/src/app/product-edit/product-edit.component.ts
+++ b/ui/pantry-ui/src/app/product-edit/product-edit.component.ts
@@ -387,7 +387,7 @@ export class ProductEditComponent implements AfterViewInit {
         next: (p) => {
           this.product = p;
           this.snackBar.open("Product saved successfully", "Close", { duration: 3000 });
-          this.router.navigate(["products"]);
+          this.router.navigate(["products", p.id]);
         },
         error: (err) => {
           this.isSaving = false;
@@ -401,7 +401,7 @@ export class ProductEditComponent implements AfterViewInit {
         next: (p) => {
           this.product = p;
           this.snackBar.open("Product saved successfully", "Close", { duration: 3000 });
-          this.router.navigate(["products"]);
+          this.router.navigate(["products", p.id]);
         },
         error: (err) => {
           this.isSaving = false;

--- a/ui/pantry-ui/src/app/recipe-edit/recipe-edit.component.ts
+++ b/ui/pantry-ui/src/app/recipe-edit/recipe-edit.component.ts
@@ -337,7 +337,7 @@ export class RecipeEditComponent implements AfterViewInit {
         next: (p) => {
           this.recipe = p;
           this.snackBar.open("Recipe saved successfully", "Close", { duration: 3000 });
-          this.router.navigate(["recipes"]);
+          this.router.navigate(["recipes", p.id]);
         },
         error: (err) => {
           this.isSaving = false;
@@ -351,7 +351,7 @@ export class RecipeEditComponent implements AfterViewInit {
         next: (p) => {
           this.recipe = p;
           this.snackBar.open("Recipe saved successfully", "Close", { duration: 3000 });
-          this.router.navigate(["recipes"]);
+          this.router.navigate(["recipes", p.id]);
         },
         error: (err) => {
           this.isSaving = false;


### PR DESCRIPTION
Modified `ProductEditComponent` and `RecipeEditComponent` to navigate to their respective view pages rather than returning to the list pages after a successful save.

---
*PR created automatically by Jules for task [11678068438512601405](https://jules.google.com/task/11678068438512601405) started by @kevdog114*